### PR TITLE
Fix Windows header issues and update docs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,10 @@
 ###############################################################################
 * text=auto
 
+# Ensure generated headers and batch files retain CRLF endings for Windows
+src/libwindpop.h eol=crlf
+build/*.bat eol=crlf
+
 ###############################################################################
 # Set default behavior for command prompt diff.
 #

--- a/README.md
+++ b/README.md
@@ -20,4 +20,8 @@ const char newPakPath[]  = "D:\\main_new.pak";
 const char unpackPath[]  = "D:\\main_unpack_pak";
 ```
 
+If MSVC reports syntax errors when including `LibWindPop.h`, verify that the
+header uses Windows line endings and no UTF-8 BOM. You can regenerate a clean
+copy by rerunning `build/win-x64-shared-library.bat`.
+
 Running the compiled executable will unpack `rawPakPath` to `unpackPath` and then repack the contents to `newPakPath`.

--- a/build/win-x64-shared-library.bat
+++ b/build/win-x64-shared-library.bat
@@ -3,3 +3,5 @@ dotnet publish ..\src\LibWindPop.csproj /p:NativeLib=Shared;PublishAot=true -c R
 copy ..\src\bin\Release\net8.0\win-x64\native\LibWindPop.lib ..\build\publish\nativeaot\shared\win-x64\LibWindPop.lib
 copy ..\src\bin\Release\net8.0\win-x64\native\LibWindPop.exp ..\build\publish\nativeaot\shared\win-x64\LibWindPop.exp
 copy ..\src\libwindpop.h ..\build\publish\nativeaot\shared\win-x64\LibWindPop.h
+rem Convert header to CRLF line endings to avoid MSVC parse errors
+powershell -Command "Get-Content ..\build\publish\nativeaot\shared\win-x64\LibWindPop.h | Out-File -Encoding ASCII ..\build\publish\nativeaot\shared\win-x64\LibWindPop.h"

--- a/src/libwindpop.h
+++ b/src/libwindpop.h
@@ -1,4 +1,4 @@
-﻿#ifndef LIBWINDPOP_H
+#ifndef LIBWINDPOP_H
 #define LIBWINDPOP_H
 #define WIND_IMPORT
 #define WIND_API __stdcall


### PR DESCRIPTION
## Summary
- normalize `libwindpop.h` for MSVC
- convert header line endings in build script
- document MSVC line ending requirements
- enforce CRLF for header and batch files via `.gitattributes`

## Testing
- `dotnet build -c Release` *(fails: The imported project "/Microsoft.Cpp.Default.props" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858ff8f650083229bfc962c2fe41a72